### PR TITLE
CodeClimate config: unify `exclude_paths`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -29,12 +29,6 @@ engines:
     exclude_fingerprints:
       - 945e912d3f8ee02458de628fbd8eca9e
       - 817d77c195dc8aedaca35d928bb11df1
-exclude_paths:
-- spec/**/*
-- vendor/**/*
-- tmp/**/*
-- log/**/*
-- .git/**/*
 ratings:
   paths:
   - Gemfile.lock
@@ -51,9 +45,12 @@ ratings:
   - "**.php"
   - "**.py"
 exclude_paths:
+- .git/**/*
 - config/**/*
 - db/**/*
 - features/**/*
+- log/**/*
 - script/**/*
 - spec/**/*
+- tmp/**/*
 - vendor/**/*


### PR DESCRIPTION
Hi @TheNotary,

I noticed you had two sets of `exclude_paths` in your yml here, which probably wasn't resulting in the exclusions you wanted, since the second key was overwriting the second.

FWIW, our CLI also always excludes `.git` automatically: I've left it here since you had it, but just so you know it shouldn't be necessary. If you are seeing files under `.git` get analyzed, that would be a bug we'd want to look at.

Thanks!
